### PR TITLE
feat: add weekly leaderboard prototype

### DIFF
--- a/data/leaderboard.json
+++ b/data/leaderboard.json
@@ -1,0 +1,10 @@
+{
+  "week": "2024-11-04",
+  "leaderboard": [
+    {"name": "Alice", "xp": 320, "quizzesWon": 3},
+    {"name": "Bob", "xp": 275, "quizzesWon": 2},
+    {"name": "Charlie", "xp": 250, "quizzesWon": 1},
+    {"name": "Diana", "xp": 200, "quizzesWon": 1},
+    {"name": "Ethan", "xp": 150, "quizzesWon": 0}
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Weekly Quiz Leaderboard</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header>
+    <h1>Weekly Quiz Leaderboard</h1>
+    <p id="week-label"></p>
+  </header>
+  <main>
+    <table id="leaderboard-table">
+      <thead>
+        <tr>
+          <th>Rank</th>
+          <th>Name</th>
+          <th>XP</th>
+          <th>Quizzes Won</th>
+        </tr>
+      </thead>
+      <tbody>
+      </tbody>
+    </table>
+  </main>
+  <script src="leaderboard.js"></script>
+</body>
+</html>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('data/leaderboard.json')
+    .then((response) => response.json())
+    .then((data) => renderLeaderboard(data));
+});
+
+function renderLeaderboard(data) {
+  const weekLabel = document.getElementById('week-label');
+  weekLabel.textContent = `Week of ${data.week}`;
+
+  const tbody = document.querySelector('#leaderboard-table tbody');
+  data.leaderboard
+    .sort((a, b) => b.xp - a.xp)
+    .forEach((player, index) => {
+      const tr = document.createElement('tr');
+      const rankTd = document.createElement('td');
+      const nameTd = document.createElement('td');
+      const xpTd = document.createElement('td');
+      const quizzesTd = document.createElement('td');
+
+      rankTd.textContent = index + 1;
+      nameTd.textContent = player.name;
+      xpTd.textContent = player.xp;
+      quizzesTd.textContent = player.quizzesWon;
+
+      if (index === 0) {
+        nameTd.innerHTML = `<span class="trophy">🏆</span>${player.name}`;
+      }
+
+      tr.appendChild(rankTd);
+      tr.appendChild(nameTd);
+      tr.appendChild(xpTd);
+      tr.appendChild(quizzesTd);
+      tbody.appendChild(tr);
+    });
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,51 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f4f4f8;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+header {
+  background: #4a90e2;
+  color: #fff;
+  width: 100%;
+  padding: 1rem 0;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+main {
+  width: 90%;
+  max-width: 600px;
+  margin-top: 2rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #e2e2e2;
+}
+
+th, td {
+  padding: 0.75rem;
+  text-align: left;
+}
+
+tbody tr:nth-child(odd) {
+  background: #fff;
+}
+
+tbody tr:nth-child(even) {
+  background: #f9f9f9;
+}
+
+.trophy {
+  font-size: 1.2rem;
+  margin-right: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add HTML/CSS/JS scaffold for weekly quiz leaderboard
- include sample data file to simulate Moodle quiz winners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a828fd571c8332b150eb6820664759